### PR TITLE
feat: add resolver removed callback and always call value removed callbacks

### DIFF
--- a/directive/controller/resolver.go
+++ b/directive/controller/resolver.go
@@ -23,6 +23,8 @@ type resolver struct {
 	// exitedCh is closed when the routine running with ctx exits
 	// may be nil if ctx == nil
 	exitedCh <-chan struct{}
+	// rels contains all release callbacks
+	rels []*callback[func()]
 	// vals are the attached values
 	// sorted by id
 	vals []*value

--- a/directive/directive.go
+++ b/directive/directive.go
@@ -291,12 +291,22 @@ type ResolverHandler interface {
 	// given value id is disposed or removed.
 	//
 	// The callback will be called if the value is removed for any reason,
-	// including if the parent handler (controller) is removed.
+	// including if the parent resolver, handler, or directive are removed.
 	//
 	// The callback might be called immediately if the value was already removed.
 	//
 	// Returns a release function to clear the callback early.
 	AddValueRemovedCallback(id uint32, cb func()) func()
+	// AddResolverRemovedCallback adds a callback that will be called when the
+	// directive resolver is removed.
+	//
+	// The callback will be called if the resolver is removed for any reason,
+	// including if the parent resolver, handler, or directive are removed.
+	//
+	// The callback might be called immediately if the resolver was already removed.
+	//
+	// Returns a release function to clear the callback early.
+	AddResolverRemovedCallback(cb func()) func()
 }
 
 // Resolver resolves values for directives.

--- a/example/boilerplate/controller/boilerplate.go
+++ b/example/boilerplate/controller/boilerplate.go
@@ -33,14 +33,26 @@ func (b *boilerplateResolver) Resolve(
 	ctx context.Context,
 	handler directive.ResolverHandler,
 ) error {
+	// Call a callback when the resolver is removed
+	handler.AddResolverRemovedCallback(func() {
+		b.c.le.Info("boilerplate resolver removed")
+	})
+
 	fullMsg := fmt.Sprintf(
 		"logging message from boilerplate directive: %s",
 		b.dir.BoilerplateMessage(),
 	)
 	b.c.le.Info(fullMsg)
-	handler.AddValue(&boilerplate_v1.BoilerplateResult{
+
+	valID, _ := handler.AddValue(&boilerplate_v1.BoilerplateResult{
 		PrintedLen: uint32(len(fullMsg)),
 	})
+
+	// call a callback when the value is removed
+	handler.AddValueRemovedCallback(valID, func() {
+		b.c.le.Info("boilerplate resolver value removed")
+	})
+
 	return nil
 }
 

--- a/example/boilerplate/controller/controller_test.go
+++ b/example/boilerplate/controller/controller_test.go
@@ -3,6 +3,7 @@ package boilerplate_controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
@@ -46,4 +47,8 @@ func TestBoilerplateController(t *testing.T) {
 		t.Fatalf("expected length 55 got %d", plen)
 	}
 	t.Log("successfully executed directive")
+
+	// Give a moment to allow the removed callbacks to fire
+	// This happens after UnrefDisposeDur
+	<-time.After(time.Millisecond * 100)
 }

--- a/example/boilerplate/v1/boilerplate.go
+++ b/example/boilerplate/v1/boilerplate.go
@@ -50,7 +50,7 @@ func (b *Boilerplate) GetValueOptions() directive.ValueOptions {
 
 		// UnrefDisposeDur is the duration to wait to dispose a directive after all
 		// references have been released.
-		UnrefDisposeDur: time.Second,
+		UnrefDisposeDur: time.Millisecond * 10,
 	}
 }
 


### PR DESCRIPTION
Value removed callbacks are often used to dispose values.

They should always be called, even if the resolver is removed due to the entire directive or controller being removed.

Add the ability to call a callback when a resolver is removed for any reason.