### PR TITLE
fix(ci): generate vendor tree before lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Vendor Go dependencies
+        run: bun run vendor
+
       - name: Cache tools
         uses: actions/cache@v5
         with:

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,9 @@ github.com/aperturerobotics/common v0.33.1/go.mod h1:SYAlWG4Y8siytCM4tSs6NUiK7T1
 github.com/aperturerobotics/fastjson v0.1.1/go.mod h1:ArP9Q7MVDi8jMPR3ljopH5drxs/qen12Hv2L7qRcPb4=
 github.com/aperturerobotics/fsnotify v1.9.1-0.20260506231828-931cb4bf1761 h1:PEEf9o0+orSLs9Z4M/PixY6ZWvGDla+a9mKq0z/TGAE=
 github.com/aperturerobotics/fsnotify v1.9.1-0.20260506231828-931cb4bf1761/go.mod h1:exy/yzvowYqAyWyO3wBTDGumPaU6ZY6GbhzwJWL7G/o=
+github.com/aperturerobotics/go-protoc-gen-prost v0.0.0-20260329113538-218ccd8f20e0 h1:6/3RSSlPEQ6LeidslB1ZCJkxW+MnfYDkvdWMDklDXw4=
 github.com/aperturerobotics/go-protoc-gen-prost v0.0.0-20260329113538-218ccd8f20e0/go.mod h1:OBb/beWmr/pDIZAUfi86j/4tBh2v5ctTxKMqSnh9c/4=
+github.com/aperturerobotics/go-protoc-wasi v0.0.0-20260329113540-600516012db3 h1:lp+V8RYcBwTX1p81swkpZn5fhw1wn2xLorzETIxRyZQ=
 github.com/aperturerobotics/go-protoc-wasi v0.0.0-20260329113540-600516012db3/go.mod h1:vEq8i7EKb32+KXGtIEZjjhNns+BdsL2dUMw4uhy3578=
 github.com/aperturerobotics/go-websocket v1.8.15-0.20260329113544-74dbfb8f11c6 h1:Utc1F7jdCc6/HrwwIikJFXt/hXxkWIWETLp/CsG6Gl0=
 github.com/aperturerobotics/go-websocket v1.8.15-0.20260329113544-74dbfb8f11c6/go.mod h1:9KnSGuqxSXbdB/Oi0I6vvfPLkclfJwMGAQaDDGVgGow=
@@ -59,6 +61,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wazero v1.12.0 h1:DuWcpNu/FzgEXgGBDp8J1Spc+CWOvvtvVyjKlaZopYU=
 github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U+kP/q2vgxh0=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=

--- a/yaml/emitterc.go
+++ b/yaml/emitterc.go
@@ -162,10 +162,9 @@ func yaml_emitter_emit(emitter *yaml_emitter_t, event *yaml_event_t) bool {
 // Check if we need to accumulate more events before emitting.
 //
 // We accumulate extra
-//  - 1 event for DOCUMENT-START
-//  - 2 events for SEQUENCE-START
-//  - 3 events for MAPPING-START
-//
+//   - 1 event for DOCUMENT-START
+//   - 2 events for SEQUENCE-START
+//   - 3 events for MAPPING-START
 func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
 	if emitter.events_head == len(emitter.events) {
 		return true
@@ -174,13 +173,10 @@ func yaml_emitter_need_more_events(emitter *yaml_emitter_t) bool {
 	switch emitter.events[emitter.events_head].typ {
 	case yaml_DOCUMENT_START_EVENT:
 		accumulate = 1
-		break
 	case yaml_SEQUENCE_START_EVENT:
 		accumulate = 2
-		break
 	case yaml_MAPPING_START_EVENT:
 		accumulate = 3
-		break
 	default:
 		return false
 	}
@@ -241,7 +237,7 @@ func yaml_emitter_increase_indent(emitter *yaml_emitter_t, flow, indentless bool
 			emitter.indent += 2
 		} else {
 			// Everything else aligns to the chosen indentation.
-			emitter.indent = emitter.best_indent*((emitter.indent+emitter.best_indent)/emitter.best_indent)
+			emitter.indent = emitter.best_indent * ((emitter.indent + emitter.best_indent) / emitter.best_indent)
 		}
 	}
 	return true
@@ -847,10 +843,6 @@ func yaml_emitter_emit_block_mapping_value(emitter *yaml_emitter_t, event *yaml_
 	return true
 }
 
-func yaml_emitter_silent_nil_event(emitter *yaml_emitter_t, event *yaml_event_t) bool {
-	return event.typ == yaml_SCALAR_EVENT && event.implicit && !emitter.canonical && len(emitter.scalar_data.value) == 0
-}
-
 // Expect a node.
 func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 	root bool, sequence bool, mapping bool, simple_key bool) bool {
@@ -1267,8 +1259,8 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		break_space    = false
 		space_break    = false
 
-		preceded_by_whitespace = false
-		followed_by_whitespace = false
+		preceded_by_whitespace bool
+		followed_by_whitespace bool
 		previous_space         = false
 		previous_break         = false
 	)
@@ -1847,6 +1839,9 @@ func yaml_emitter_write_double_quoted_scalar(emitter *yaml_emitter_t, value []by
 
 func yaml_emitter_write_block_scalar_hints(emitter *yaml_emitter_t, value []byte) bool {
 	if is_space(value, 0) || is_break(value, 0) {
+		if emitter.best_indent < 2 || emitter.best_indent > 9 {
+			return yaml_emitter_set_emitter_error(emitter, "indent must be between 2 and 9")
+		}
 		indent_hint := []byte{'0' + byte(emitter.best_indent)}
 		if !yaml_emitter_write_indicator(emitter, indent_hint, false, false, false) {
 			return false

--- a/yaml/parserc.go
+++ b/yaml/parserc.go
@@ -227,7 +227,8 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 
 // Parse the production:
 // stream   ::= STREAM-START implicit_document? explicit_document* STREAM-END
-//              ************
+//
+//	************
 func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -249,9 +250,12 @@ func yaml_parser_parse_stream_start(parser *yaml_parser_t, event *yaml_event_t) 
 
 // Parse the productions:
 // implicit_document    ::= block_node DOCUMENT-END*
-//                          *
+//
+//	*
+//
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-//                          *************************
+//
+//	*************************
 func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t, implicit bool) bool {
 
 	token := peek_token(parser)
@@ -356,8 +360,8 @@ func yaml_parser_parse_document_start(parser *yaml_parser_t, event *yaml_event_t
 
 // Parse the productions:
 // explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
-//                                                    ***********
 //
+//	***********
 func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -379,9 +383,10 @@ func yaml_parser_parse_document_content(parser *yaml_parser_t, event *yaml_event
 
 // Parse the productions:
 // implicit_document    ::= block_node DOCUMENT-END*
-//                                     *************
-// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 //
+//	*************
+//
+// explicit_document    ::= DIRECTIVE* DOCUMENT-START block_node? DOCUMENT-END*
 func yaml_parser_parse_document_end(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -428,30 +433,41 @@ func yaml_parser_set_event_comments(parser *yaml_parser_t, event *yaml_event_t) 
 
 // Parse the productions:
 // block_node_or_indentless_sequence    ::=
-//                          ALIAS
-//                          *****
-//                          | properties (block_content | indentless_block_sequence)?
-//                            **********  *
-//                          | block_content | indentless_block_sequence
-//                            *
+//
+//	ALIAS
+//	*****
+//	| properties (block_content | indentless_block_sequence)?
+//	  **********  *
+//	| block_content | indentless_block_sequence
+//	  *
+//
 // block_node           ::= ALIAS
-//                          *****
-//                          | properties block_content?
-//                            ********** *
-//                          | block_content
-//                            *
+//
+//	*****
+//	| properties block_content?
+//	  ********** *
+//	| block_content
+//	  *
+//
 // flow_node            ::= ALIAS
-//                          *****
-//                          | properties flow_content?
-//                            ********** *
-//                          | flow_content
-//                            *
+//
+//	*****
+//	| properties flow_content?
+//	  ********** *
+//	| flow_content
+//	  *
+//
 // properties           ::= TAG ANCHOR? | ANCHOR TAG?
-//                          *************************
+//
+//	*************************
+//
 // block_content        ::= block_collection | flow_collection | SCALAR
-//                                                               ******
+//
+//	******
+//
 // flow_content         ::= flow_collection | SCALAR
-//                                            ******
+//
+//	******
 func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, indentless_sequence bool) bool {
 	//defer trace("yaml_parser_parse_node", "block:", block, "indentless_sequence:", indentless_sequence)()
 
@@ -480,7 +496,8 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 	var tag_token bool
 	var tag_handle, tag_suffix, anchor []byte
 	var tag_mark yaml_mark_t
-	if token.typ == yaml_ANCHOR_TOKEN {
+	switch token.typ {
+	case yaml_ANCHOR_TOKEN:
 		anchor = token.value
 		start_mark = token.start_mark
 		end_mark = token.end_mark
@@ -501,7 +518,7 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 				return false
 			}
 		}
-	} else if token.typ == yaml_TAG_TOKEN {
+	case yaml_TAG_TOKEN:
 		tag_token = true
 		tag_handle = token.value
 		tag_suffix = token.suffix
@@ -528,7 +545,6 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 	if tag_token {
 		if len(tag_handle) == 0 {
 			tag = tag_suffix
-			tag_suffix = nil
 		} else {
 			for i := range parser.tag_directives {
 				if bytes.Equal(parser.tag_directives[i].handle, tag_handle) {
@@ -682,8 +698,8 @@ func yaml_parser_parse_node(parser *yaml_parser_t, event *yaml_event_t, block, i
 
 // Parse the productions:
 // block_sequence ::= BLOCK-SEQUENCE-START (BLOCK-ENTRY block_node?)* BLOCK-END
-//                    ********************  *********** *             *********
 //
+//	********************  *********** *             *********
 func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -740,7 +756,8 @@ func yaml_parser_parse_block_sequence_entry(parser *yaml_parser_t, event *yaml_e
 
 // Parse the productions:
 // indentless_sequence  ::= (BLOCK-ENTRY block_node?)+
-//                           *********** *
+//
+//	*********** *
 func yaml_parser_parse_indentless_sequence_entry(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -805,14 +822,14 @@ func yaml_parser_split_stem_comment(parser *yaml_parser_t, stem_len int) {
 
 // Parse the productions:
 // block_mapping        ::= BLOCK-MAPPING_START
-//                          *******************
-//                          ((KEY block_node_or_indentless_sequence?)?
-//                            *** *
-//                          (VALUE block_node_or_indentless_sequence?)?)*
 //
-//                          BLOCK-END
-//                          *********
+//	*******************
+//	((KEY block_node_or_indentless_sequence?)?
+//	  *** *
+//	(VALUE block_node_or_indentless_sequence?)?)*
 //
+//	BLOCK-END
+//	*********
 func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -841,7 +858,8 @@ func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_even
 		return true
 	}
 
-	if token.typ == yaml_KEY_TOKEN {
+	switch token.typ {
+	case yaml_KEY_TOKEN:
 		mark := token.end_mark
 		skip_token(parser)
 		token = peek_token(parser)
@@ -857,7 +875,7 @@ func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_even
 			parser.state = yaml_PARSE_BLOCK_MAPPING_VALUE_STATE
 			return yaml_parser_process_empty_scalar(parser, event, mark)
 		}
-	} else if token.typ == yaml_BLOCK_END_TOKEN {
+	case yaml_BLOCK_END_TOKEN:
 		parser.state = parser.states[len(parser.states)-1]
 		parser.states = parser.states[:len(parser.states)-1]
 		parser.marks = parser.marks[:len(parser.marks)-1]
@@ -881,13 +899,11 @@ func yaml_parser_parse_block_mapping_key(parser *yaml_parser_t, event *yaml_even
 // Parse the productions:
 // block_mapping        ::= BLOCK-MAPPING_START
 //
-//                          ((KEY block_node_or_indentless_sequence?)?
+//	((KEY block_node_or_indentless_sequence?)?
 //
-//                          (VALUE block_node_or_indentless_sequence?)?)*
-//                           ***** *
-//                          BLOCK-END
-//
-//
+//	(VALUE block_node_or_indentless_sequence?)?)*
+//	 ***** *
+//	BLOCK-END
 func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -915,16 +931,18 @@ func yaml_parser_parse_block_mapping_value(parser *yaml_parser_t, event *yaml_ev
 
 // Parse the productions:
 // flow_sequence        ::= FLOW-SEQUENCE-START
-//                          *******************
-//                          (flow_sequence_entry FLOW-ENTRY)*
-//                           *                   **********
-//                          flow_sequence_entry?
-//                          *
-//                          FLOW-SEQUENCE-END
-//                          *****************
-// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                          *
 //
+//	*******************
+//	(flow_sequence_entry FLOW-ENTRY)*
+//	 *                   **********
+//	flow_sequence_entry?
+//	*
+//	FLOW-SEQUENCE-END
+//	*****************
+//
+// flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//
+//	*
 func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -987,11 +1005,10 @@ func yaml_parser_parse_flow_sequence_entry(parser *yaml_parser_t, event *yaml_ev
 	return true
 }
 
-//
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                      *** *
 //
+//	*** *
 func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1011,8 +1028,8 @@ func yaml_parser_parse_flow_sequence_entry_mapping_key(parser *yaml_parser_t, ev
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                                      ***** *
 //
+//	***** *
 func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1035,8 +1052,8 @@ func yaml_parser_parse_flow_sequence_entry_mapping_value(parser *yaml_parser_t, 
 
 // Parse the productions:
 // flow_sequence_entry  ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                                                      *
 //
+//	*
 func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, event *yaml_event_t) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1053,16 +1070,17 @@ func yaml_parser_parse_flow_sequence_entry_mapping_end(parser *yaml_parser_t, ev
 
 // Parse the productions:
 // flow_mapping         ::= FLOW-MAPPING-START
-//                          ******************
-//                          (flow_mapping_entry FLOW-ENTRY)*
-//                           *                  **********
-//                          flow_mapping_entry?
-//                          ******************
-//                          FLOW-MAPPING-END
-//                          ****************
-// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                          *           *** *
 //
+//	******************
+//	(flow_mapping_entry FLOW-ENTRY)*
+//	 *                  **********
+//	flow_mapping_entry?
+//	******************
+//	FLOW-MAPPING-END
+//	****************
+//
+// flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
+//   - *** *
 func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event_t, first bool) bool {
 	if first {
 		token := peek_token(parser)
@@ -1128,8 +1146,7 @@ func yaml_parser_parse_flow_mapping_key(parser *yaml_parser_t, event *yaml_event
 
 // Parse the productions:
 // flow_mapping_entry   ::= flow_node | KEY flow_node? (VALUE flow_node?)?
-//                                   *                  ***** *
-//
+//   - ***** *
 func yaml_parser_parse_flow_mapping_value(parser *yaml_parser_t, event *yaml_event_t, empty bool) bool {
 	token := peek_token(parser)
 	if token == nil {
@@ -1186,7 +1203,8 @@ func yaml_parser_process_directives(parser *yaml_parser_t,
 	}
 
 	for token.typ == yaml_VERSION_DIRECTIVE_TOKEN || token.typ == yaml_TAG_DIRECTIVE_TOKEN {
-		if token.typ == yaml_VERSION_DIRECTIVE_TOKEN {
+		switch token.typ {
+		case yaml_VERSION_DIRECTIVE_TOKEN:
 			if version_directive != nil {
 				yaml_parser_set_parser_error(parser,
 					"found duplicate %YAML directive", token.start_mark)
@@ -1201,7 +1219,7 @@ func yaml_parser_process_directives(parser *yaml_parser_t,
 				major: token.major,
 				minor: token.minor,
 			}
-		} else if token.typ == yaml_TAG_DIRECTIVE_TOKEN {
+		case yaml_TAG_DIRECTIVE_TOKEN:
 			value := yaml_tag_directive_t{
 				handle: token.value,
 				prefix: token.prefix,

--- a/yaml/readerc.go
+++ b/yaml/readerc.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -118,16 +118,6 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 	// [Go] This function was changed to guarantee the requested length size at EOF.
 	// The fact we need to do this is pretty awful, but the description above implies
 	// for that to be the case, and there are tests
-
-	// If the EOF flag is set and the raw buffer is empty, do nothing.
-	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {
-		// [Go] ACTUALLY! Read the documentation of this function above.
-		// This is just broken. To return true, we need to have the
-		// given length in the buffer. Not doing that means every single
-		// check that calls this function to make sure the buffer has a
-		// given length is Go) panicking; or C) accessing invalid memory.
-		//return true
-	}
 
 	// Return if the buffer contains enough characters.
 	if parser.unread >= length {

--- a/yaml/scannerc.go
+++ b/yaml/scannerc.go
@@ -24,7 +24,9 @@ package yaml
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
+	"math"
 )
 
 // Introduction
@@ -502,13 +504,6 @@ import (
 //      BLOCK-END
 //
 
-// Ensure that the buffer contains the required number of characters.
-// Return true on success, false on failure (reader error or memory error).
-func cache(parser *yaml_parser_t, length int) bool {
-	// [Go] This was inlined: !cache(A, B) -> unread < B && !update(A, B)
-	return parser.unread >= length || yaml_parser_update_buffer(parser, length)
-}
-
 // Advance the buffer pointer.
 func skip(parser *yaml_parser_t) {
 	if !is_blank(parser.buffer, parser.buffer_pos) {
@@ -598,35 +593,6 @@ func read_line(parser *yaml_parser_t, s []byte) []byte {
 	return s
 }
 
-// Get the next token.
-func yaml_parser_scan(parser *yaml_parser_t, token *yaml_token_t) bool {
-	// Erase the token object.
-	*token = yaml_token_t{} // [Go] Is this necessary?
-
-	// No tokens after STREAM-END or error.
-	if parser.stream_end_produced || parser.error != yaml_NO_ERROR {
-		return true
-	}
-
-	// Ensure that the tokens queue contains enough tokens.
-	if !parser.token_available {
-		if !yaml_parser_fetch_more_tokens(parser) {
-			return false
-		}
-	}
-
-	// Fetch the next token from the queue.
-	*token = parser.tokens[parser.tokens_head]
-	parser.tokens_head++
-	parser.tokens_parsed++
-	parser.token_available = false
-
-	if token.typ == yaml_STREAM_END_TOKEN {
-		parser.stream_end_produced = true
-	}
-	return true
-}
-
 // Set the scanner error and return false.
 func yaml_parser_set_scanner_error(parser *yaml_parser_t, context string, context_mark yaml_mark_t, problem string) bool {
 	parser.error = yaml_SCANNER_ERROR
@@ -643,13 +609,6 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 		context = "while parsing a %TAG directive"
 	}
 	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
-}
-
-func trace(args ...interface{}) func() {
-	pargs := append([]interface{}{"+++"}, args...)
-	fmt.Println(pargs...)
-	pargs = append([]interface{}{"---"}, args...)
-	return func() { fmt.Println(pargs...) }
 }
 
 // Ensure that the tokens queue contains at least one token which can be
@@ -857,16 +816,16 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) (ok bool) {
 	//switch parser.buffer[parser.buffer_pos] {
 	//case '-', '?', ':', ',', '?', '-', ',', ':', ']', '[', '}', '{', '&', '#', '!', '*', '>', '|', '"', '\'', '@', '%', '-', '`':
 	//}
-	if !(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '-' ||
-		parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':' ||
-		parser.buffer[parser.buffer_pos] == ',' || parser.buffer[parser.buffer_pos] == '[' ||
-		parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '{' ||
-		parser.buffer[parser.buffer_pos] == '}' || parser.buffer[parser.buffer_pos] == '#' ||
-		parser.buffer[parser.buffer_pos] == '&' || parser.buffer[parser.buffer_pos] == '*' ||
-		parser.buffer[parser.buffer_pos] == '!' || parser.buffer[parser.buffer_pos] == '|' ||
-		parser.buffer[parser.buffer_pos] == '>' || parser.buffer[parser.buffer_pos] == '\'' ||
-		parser.buffer[parser.buffer_pos] == '"' || parser.buffer[parser.buffer_pos] == '%' ||
-		parser.buffer[parser.buffer_pos] == '@' || parser.buffer[parser.buffer_pos] == '`') ||
+	if (!is_blankz(parser.buffer, parser.buffer_pos) && parser.buffer[parser.buffer_pos] != '-' &&
+		parser.buffer[parser.buffer_pos] != '?' && parser.buffer[parser.buffer_pos] != ':' &&
+		parser.buffer[parser.buffer_pos] != ',' && parser.buffer[parser.buffer_pos] != '[' &&
+		parser.buffer[parser.buffer_pos] != ']' && parser.buffer[parser.buffer_pos] != '{' &&
+		parser.buffer[parser.buffer_pos] != '}' && parser.buffer[parser.buffer_pos] != '#' &&
+		parser.buffer[parser.buffer_pos] != '&' && parser.buffer[parser.buffer_pos] != '*' &&
+		parser.buffer[parser.buffer_pos] != '!' && parser.buffer[parser.buffer_pos] != '|' &&
+		parser.buffer[parser.buffer_pos] != '>' && parser.buffer[parser.buffer_pos] != '\'' &&
+		parser.buffer[parser.buffer_pos] != '"' && parser.buffer[parser.buffer_pos] != '%' &&
+		parser.buffer[parser.buffer_pos] != '@' && parser.buffer[parser.buffer_pos] != '`') ||
 		(parser.buffer[parser.buffer_pos] == '-' && !is_blank(parser.buffer, parser.buffer_pos+1)) ||
 		(parser.flow_level == 0 &&
 			(parser.buffer[parser.buffer_pos] == '?' || parser.buffer[parser.buffer_pos] == ':') &&
@@ -1298,10 +1257,6 @@ func yaml_parser_fetch_block_entry(parser *yaml_parser_t) bool {
 		if !yaml_parser_roll_indent(parser, parser.mark.column, -1, yaml_BLOCK_SEQUENCE_START_TOKEN, parser.mark) {
 			return false
 		}
-	} else {
-		// It is an error for the '-' indicator to occur in the flow context,
-		// but we let the Parser detect and report about it because the Parser
-		// is able to point to the context.
 	}
 
 	// Reset any potential simple keys on the current flow level.
@@ -1614,11 +1569,11 @@ func yaml_parser_scan_to_next_token(parser *yaml_parser_t) bool {
 // Scan a YAML-DIRECTIVE or TAG-DIRECTIVE token.
 //
 // Scope:
-//      %YAML    1.1    # a comment \n
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //
+//	%YAML    1.1    # a comment \n
+//	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 func yaml_parser_scan_directive(parser *yaml_parser_t, token *yaml_token_t) bool {
 	// Eat '%'.
 	start_mark := parser.mark
@@ -1719,11 +1674,11 @@ func yaml_parser_scan_directive(parser *yaml_parser_t, token *yaml_token_t) bool
 // Scan the directive name.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//       ^^^^
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//       ^^^
 //
+//	%YAML   1.1     # a comment \n
+//	 ^^^^
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	 ^^^
 func yaml_parser_scan_directive_name(parser *yaml_parser_t, start_mark yaml_mark_t, name *[]byte) bool {
 	// Consume the directive name.
 	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
@@ -1758,8 +1713,9 @@ func yaml_parser_scan_directive_name(parser *yaml_parser_t, start_mark yaml_mark
 // Scan the value of VERSION-DIRECTIVE.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//           ^^^^^^
+//
+//	%YAML   1.1     # a comment \n
+//	     ^^^^^^
 func yaml_parser_scan_version_directive_value(parser *yaml_parser_t, start_mark yaml_mark_t, major, minor *int8) bool {
 	// Eat whitespaces.
 	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
@@ -1797,17 +1753,18 @@ const max_number_length = 2
 // Scan the version number of VERSION-DIRECTIVE.
 //
 // Scope:
-//      %YAML   1.1     # a comment \n
-//              ^
-//      %YAML   1.1     # a comment \n
-//                ^
+//
+//	%YAML   1.1     # a comment \n
+//	        ^
+//	%YAML   1.1     # a comment \n
+//	          ^
 func yaml_parser_scan_version_directive_number(parser *yaml_parser_t, start_mark yaml_mark_t, number *int8) bool {
 
 	// Repeat while the next character is digit.
 	if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 		return false
 	}
-	var value, length int8
+	var value, length int
 	for is_digit(parser.buffer, parser.buffer_pos) {
 		// Check if the number is too long.
 		length++
@@ -1815,7 +1772,7 @@ func yaml_parser_scan_version_directive_number(parser *yaml_parser_t, start_mark
 			return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
 				start_mark, "found extremely long version number")
 		}
-		value = value*10 + int8(as_digit(parser.buffer, parser.buffer_pos))
+		value = value*10 + as_digit(parser.buffer, parser.buffer_pos)
 		skip(parser)
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false
@@ -1827,16 +1784,20 @@ func yaml_parser_scan_version_directive_number(parser *yaml_parser_t, start_mark
 		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
 			start_mark, "did not find expected version number")
 	}
-	*number = value
+	if value > math.MaxInt8 {
+		return yaml_parser_set_scanner_error(parser, "while scanning a %YAML directive",
+			start_mark, "version number exceeds supported range")
+	}
+	*number = int8(value)
 	return true
 }
 
 // Scan the value of a TAG-DIRECTIVE token.
 //
 // Scope:
-//      %TAG    !yaml!  tag:yaml.org,2002:  \n
-//          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //
+//	%TAG    !yaml!  tag:yaml.org,2002:  \n
+//	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 func yaml_parser_scan_tag_directive_value(parser *yaml_parser_t, start_mark yaml_mark_t, handle, prefix *[]byte) bool {
 	var handle_value, prefix_value []byte
 
@@ -1924,11 +1885,11 @@ func yaml_parser_scan_anchor(parser *yaml_parser_t, token *yaml_token_t, typ yam
 	 */
 
 	if len(s) == 0 ||
-		!(is_blankz(parser.buffer, parser.buffer_pos) || parser.buffer[parser.buffer_pos] == '?' ||
-			parser.buffer[parser.buffer_pos] == ':' || parser.buffer[parser.buffer_pos] == ',' ||
-			parser.buffer[parser.buffer_pos] == ']' || parser.buffer[parser.buffer_pos] == '}' ||
-			parser.buffer[parser.buffer_pos] == '%' || parser.buffer[parser.buffer_pos] == '@' ||
-			parser.buffer[parser.buffer_pos] == '`') {
+		(!is_blankz(parser.buffer, parser.buffer_pos) && parser.buffer[parser.buffer_pos] != '?' &&
+			parser.buffer[parser.buffer_pos] != ':' && parser.buffer[parser.buffer_pos] != ',' &&
+			parser.buffer[parser.buffer_pos] != ']' && parser.buffer[parser.buffer_pos] != '}' &&
+			parser.buffer[parser.buffer_pos] != '%' && parser.buffer[parser.buffer_pos] != '@' &&
+			parser.buffer[parser.buffer_pos] != '`') {
 		context := "while scanning an alias"
 		if typ == yaml_ANCHOR_TOKEN {
 			context = "while scanning an anchor"
@@ -2151,15 +2112,18 @@ func yaml_parser_scan_uri_escapes(parser *yaml_parser_t, directive bool, start_m
 			return false
 		}
 
-		if !(parser.buffer[parser.buffer_pos] == '%' &&
-			is_hex(parser.buffer, parser.buffer_pos+1) &&
-			is_hex(parser.buffer, parser.buffer_pos+2)) {
+		if parser.buffer[parser.buffer_pos] != '%' || !is_hex(parser.buffer, parser.buffer_pos+1) || !is_hex(parser.buffer, parser.buffer_pos+2) {
 			return yaml_parser_set_scanner_tag_error(parser, directive,
 				start_mark, "did not find URI escaped octet")
 		}
 
-		// Get the octet.
-		octet := byte((as_hex(parser.buffer, parser.buffer_pos+1) << 4) + as_hex(parser.buffer, parser.buffer_pos+2))
+		// Decode the checked hexadecimal pair into one octet.
+		var decoded [1]byte
+		if _, err := hex.Decode(decoded[:], parser.buffer[parser.buffer_pos+1:parser.buffer_pos+3]); err != nil {
+			return yaml_parser_set_scanner_tag_error(parser, directive,
+				start_mark, "did not find URI escaped octet")
+		}
+		octet := decoded[0]
 
 		// If it is the leading octet, determine the length of the UTF-8 sequence.
 		if w == 1024 {
@@ -2765,7 +2729,7 @@ func yaml_parser_scan_plain_scalar(parser *yaml_parser_t, token *yaml_token_t) b
 		}
 
 		// Is it the end?
-		if !(is_blank(parser.buffer, parser.buffer_pos) || is_break(parser.buffer, parser.buffer_pos)) {
+		if !is_blank(parser.buffer, parser.buffer_pos) && !is_break(parser.buffer, parser.buffer_pos) {
 			break
 		}
 
@@ -2847,7 +2811,7 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 			continue
 		}
 		if parser.buffer[parser.buffer_pos+peek] == '#' {
-			seen := parser.mark.index+peek
+			seen := parser.mark.index + peek
 			for {
 				if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 					return false
@@ -2876,7 +2840,7 @@ func yaml_parser_scan_line_comment(parser *yaml_parser_t, token_mark yaml_mark_t
 		parser.comments = append(parser.comments, yaml_comment_t{
 			token_mark: token_mark,
 			start_mark: start_mark,
-			line: text,
+			line:       text,
 		})
 	}
 	return true
@@ -2910,7 +2874,7 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 	// the foot is the line below it.
 	var foot_line = -1
 	if scan_mark.line > 0 {
-		foot_line = parser.mark.line-parser.newlines+1
+		foot_line = parser.mark.line - parser.newlines + 1
 		if parser.newlines == 0 && parser.mark.column > 1 {
 			foot_line++
 		}
@@ -2996,7 +2960,7 @@ func yaml_parser_scan_comments(parser *yaml_parser_t, scan_mark yaml_mark_t) boo
 		recent_empty = false
 
 		// Consume until after the consumed comment line.
-		seen := parser.mark.index+peek
+		seen := parser.mark.index + peek
 		for {
 			if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 				return false

--- a/yaml/writerc.go
+++ b/yaml/writerc.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +28,51 @@ func TestYAMLToJSONScalars(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 			assertJSONEqual(t, got, []byte(test.json))
+		})
+	}
+}
+
+func TestYAMLToJSONDirectives(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantJSON   string
+		wantErrSub string
+	}{
+		{
+			name:     "version",
+			yaml:     "%YAML 1.1\n---\nvalue\n",
+			wantJSON: `"value"`,
+		},
+		{
+			name:       "version overflow",
+			yaml:       "%YAML 123.1\n---\nvalue\n",
+			wantErrSub: "found extremely long version number",
+		},
+		{
+			name:     "escaped tag URI",
+			yaml:     "%TAG !e! tag:example.com,2000:app/%66oo\n---\n!e!bar value\n",
+			wantJSON: `"value"`,
+		},
+		{
+			name:       "invalid escaped tag URI",
+			yaml:       "%TAG !e! tag:example.com,2000:app/%GG\n---\n!e!bar value\n",
+			wantErrSub: "did not find URI escaped octet",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := YAMLToJSON([]byte(test.yaml))
+			if test.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrSub) {
+					t.Fatalf("expected error containing %q, got %v", test.wantErrSub, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			assertJSONEqual(t, got, []byte(test.wantJSON))
 		})
 	}
 }

--- a/yaml/yamlh.go
+++ b/yaml/yamlh.go
@@ -22,10 +22,7 @@
 
 package yaml
 
-import (
-	"fmt"
-	"io"
-)
+import "fmt"
 
 // The version directive data.
 type yaml_version_directive_t struct {
@@ -108,22 +105,16 @@ type yaml_sequence_style_t yaml_style_t
 
 // Sequence styles.
 const (
-	// Let the emitter choose the style.
-	yaml_ANY_SEQUENCE_STYLE yaml_sequence_style_t = iota
-
-	yaml_BLOCK_SEQUENCE_STYLE // The block sequence style.
-	yaml_FLOW_SEQUENCE_STYLE  // The flow sequence style.
+	yaml_BLOCK_SEQUENCE_STYLE yaml_sequence_style_t = 1 + iota // The block sequence style.
+	yaml_FLOW_SEQUENCE_STYLE                                   // The flow sequence style.
 )
 
 type yaml_mapping_style_t yaml_style_t
 
 // Mapping styles.
 const (
-	// Let the emitter choose the style.
-	yaml_ANY_MAPPING_STYLE yaml_mapping_style_t = iota
-
-	yaml_BLOCK_MAPPING_STYLE // The block mapping style.
-	yaml_FLOW_MAPPING_STYLE  // The flow mapping style.
+	yaml_BLOCK_MAPPING_STYLE yaml_mapping_style_t = 1 + iota // The block mapping style.
+	yaml_FLOW_MAPPING_STYLE                                  // The flow mapping style.
 )
 
 // Tokens
@@ -333,104 +324,6 @@ func (e *yaml_event_t) scalar_style() yaml_scalar_style_t     { return yaml_scal
 func (e *yaml_event_t) sequence_style() yaml_sequence_style_t { return yaml_sequence_style_t(e.style) }
 func (e *yaml_event_t) mapping_style() yaml_mapping_style_t   { return yaml_mapping_style_t(e.style) }
 
-// Nodes
-
-const (
-	yaml_NULL_TAG      = "tag:yaml.org,2002:null"      // The tag !!null with the only possible value: null.
-	yaml_BOOL_TAG      = "tag:yaml.org,2002:bool"      // The tag !!bool with the values: true and false.
-	yaml_STR_TAG       = "tag:yaml.org,2002:str"       // The tag !!str for string values.
-	yaml_INT_TAG       = "tag:yaml.org,2002:int"       // The tag !!int for integer values.
-	yaml_FLOAT_TAG     = "tag:yaml.org,2002:float"     // The tag !!float for float values.
-	yaml_TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp" // The tag !!timestamp for date and time values.
-
-	yaml_SEQ_TAG = "tag:yaml.org,2002:seq" // The tag !!seq is used to denote sequences.
-	yaml_MAP_TAG = "tag:yaml.org,2002:map" // The tag !!map is used to denote mapping.
-
-	// Not in original libyaml.
-	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
-	yaml_MERGE_TAG  = "tag:yaml.org,2002:merge"
-
-	yaml_DEFAULT_SCALAR_TAG   = yaml_STR_TAG // The default scalar tag is !!str.
-	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG // The default sequence tag is !!seq.
-	yaml_DEFAULT_MAPPING_TAG  = yaml_MAP_TAG // The default mapping tag is !!map.
-)
-
-type yaml_node_type_t int
-
-// Node types.
-const (
-	// An empty node.
-	yaml_NO_NODE yaml_node_type_t = iota
-
-	yaml_SCALAR_NODE   // A scalar node.
-	yaml_SEQUENCE_NODE // A sequence node.
-	yaml_MAPPING_NODE  // A mapping node.
-)
-
-// An element of a sequence node.
-type yaml_node_item_t int
-
-// An element of a mapping node.
-type yaml_node_pair_t struct {
-	key   int // The key of the element.
-	value int // The value of the element.
-}
-
-// The node structure.
-type yaml_node_t struct {
-	typ yaml_node_type_t // The node type.
-	tag []byte           // The node tag.
-
-	// The node data.
-
-	// The scalar parameters (for yaml_SCALAR_NODE).
-	scalar struct {
-		value  []byte              // The scalar value.
-		length int                 // The length of the scalar value.
-		style  yaml_scalar_style_t // The scalar style.
-	}
-
-	// The sequence parameters (for YAML_SEQUENCE_NODE).
-	sequence struct {
-		items_data []yaml_node_item_t    // The stack of sequence items.
-		style      yaml_sequence_style_t // The sequence style.
-	}
-
-	// The mapping parameters (for yaml_MAPPING_NODE).
-	mapping struct {
-		pairs_data  []yaml_node_pair_t   // The stack of mapping pairs (key, value).
-		pairs_start *yaml_node_pair_t    // The beginning of the stack.
-		pairs_end   *yaml_node_pair_t    // The end of the stack.
-		pairs_top   *yaml_node_pair_t    // The top of the stack.
-		style       yaml_mapping_style_t // The mapping style.
-	}
-
-	start_mark yaml_mark_t // The beginning of the node.
-	end_mark   yaml_mark_t // The end of the node.
-
-}
-
-// The document structure.
-type yaml_document_t struct {
-
-	// The document nodes.
-	nodes []yaml_node_t
-
-	// The version directive.
-	version_directive *yaml_version_directive_t
-
-	// The list of tag directives.
-	tag_directives_data  []yaml_tag_directive_t
-	tag_directives_start int // The beginning of the tag directives list.
-	tag_directives_end   int // The end of the tag directives list.
-
-	start_implicit int // Is the document start indicator implicit?
-	end_implicit   int // Is the document end indicator implicit?
-
-	// The start/end of the document.
-	start_mark, end_mark yaml_mark_t
-}
-
 // The prototype of a read handler.
 //
 // The read handler is called when the parser needs to read more bytes from the
@@ -438,7 +331,9 @@ type yaml_document_t struct {
 // The number of written bytes should be set to the size_read variable.
 //
 // [in,out]   data        A pointer to an application data specified by
-//                        yaml_parser_set_input().
+//
+//	yaml_parser_set_input().
+//
 // [out]      buffer      The buffer to write the data from the source.
 // [in]       size        The size of the buffer.
 // [out]      size_read   The actual number of bytes read from the source.
@@ -541,13 +436,6 @@ func (ps yaml_parser_state_t) String() string {
 	return "<unknown parser state>"
 }
 
-// This structure holds aliases data.
-type yaml_alias_data_t struct {
-	anchor []byte      // The anchor.
-	index  int         // The node id.
-	mark   yaml_mark_t // The anchor mark.
-}
-
 // The parser structure.
 //
 // All members are internal. Manage the structure using the
@@ -573,9 +461,8 @@ type yaml_parser_t struct {
 
 	read_handler yaml_read_handler_t // Read handler.
 
-	input_reader io.Reader // File input data.
-	input        []byte    // String input data.
-	input_pos    int
+	input     []byte // String input data.
+	input_pos int
 
 	eof bool // EOF flag
 
@@ -631,15 +518,9 @@ type yaml_parser_t struct {
 	marks          []yaml_mark_t          // The stack of marks.
 	tag_directives []yaml_tag_directive_t // The list of TAG directives.
 
-	// Dumper stuff
-
-	aliases []yaml_alias_data_t // The alias data.
-
-	document *yaml_document_t // The currently parsed document.
 }
 
 type yaml_comment_t struct {
-
 	scan_mark  yaml_mark_t // Position where scanning for comments started
 	token_mark yaml_mark_t // Position after which tokens will be associated with this comment
 	start_mark yaml_mark_t // Position of '#' comment mark
@@ -659,13 +540,14 @@ type yaml_comment_t struct {
 // @a buffer to the output.
 //
 // @param[in,out]   data        A pointer to an application data specified by
-//                              yaml_emitter_set_output().
+//
+//	yaml_emitter_set_output().
+//
 // @param[in]       buffer      The buffer with bytes to be written.
 // @param[in]       size        The size of the buffer.
 //
 // @returns On success, the handler should return @c 1.  If the handler failed,
 // the returned value should be @c 0.
-//
 type yaml_write_handler_t func(emitter *yaml_emitter_t, buffer []byte) error
 
 type yaml_emitter_state_t int
@@ -711,14 +593,12 @@ type yaml_emitter_t struct {
 
 	write_handler yaml_write_handler_t // Write handler.
 
-	output_buffer *[]byte   // String output data.
-	output_writer io.Writer // File output data.
+	output_buffer *[]byte // String output data.
 
 	buffer     []byte // The working buffer.
 	buffer_pos int    // The current position of the buffer.
 
-	raw_buffer     []byte // The raw buffer.
-	raw_buffer_pos int    // The current position of the buffer.
+	raw_buffer []byte // The raw buffer.
 
 	encoding yaml_encoding_t // The stream encoding.
 
@@ -788,20 +668,4 @@ type yaml_emitter_t struct {
 	tail_comment []byte
 
 	key_line_comment []byte
-
-	// Dumper stuff
-
-	opened bool // If the stream was already opened?
-	closed bool // If the stream was already closed?
-
-	// The information associated with the document nodes.
-	anchors *struct {
-		references int  // The number of references.
-		anchor     int  // The anchor id.
-		serialized bool // If the node has been emitted?
-	}
-
-	last_anchor_id int // The last assigned anchor id.
-
-	document *yaml_document_t // The currently emitted document.
 }

--- a/yaml/yamlprivateh.go
+++ b/yaml/yamlprivateh.go
@@ -1,17 +1,17 @@
-// 
+//
 // Copyright (c) 2011-2019 Canonical Ltd
 // Copyright (c) 2006-2010 Kirill Simonov
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to
 // use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 // of the Software, and to permit persons to whom the Software is furnished to do
 // so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -90,8 +90,8 @@ func is_printable(b []byte, i int) bool {
 		(b[i] == 0xED && b[i+1] < 0xA0) ||
 		(b[i] == 0xEE) ||
 		(b[i] == 0xEF && // #xE000 <= . <= #xFFFD
-			!(b[i+1] == 0xBB && b[i+2] == 0xBF) && // && . != #xFEFF
-			!(b[i+1] == 0xBF && (b[i+2] == 0xBE || b[i+2] == 0xBF))))
+			(b[i+1] != 0xBB || b[i+2] != 0xBF) && // && . != #xFEFF
+			(b[i+1] != 0xBF || b[i+2] != 0xBE && b[i+2] != 0xBF)))
 }
 
 // Check if the character at the specified position is NUL.
@@ -137,8 +137,8 @@ func is_crlf(b []byte, i int) bool {
 func is_breakz(b []byte, i int) bool {
 	//return is_break(b, i) || is_z(b, i)
 	return (
-		// is_break:
-		b[i] == '\r' || // CR (#xD)
+	// is_break:
+	b[i] == '\r' || // CR (#xD)
 		b[i] == '\n' || // LF (#xA)
 		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
 		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
@@ -147,27 +147,12 @@ func is_breakz(b []byte, i int) bool {
 		b[i] == 0)
 }
 
-// Check if the character is a line break, space, or NUL.
-func is_spacez(b []byte, i int) bool {
-	//return is_space(b, i) || is_breakz(b, i)
-	return (
-		// is_space:
-		b[i] == ' ' ||
-		// is_breakz:
-		b[i] == '\r' || // CR (#xD)
-		b[i] == '\n' || // LF (#xA)
-		b[i] == 0xC2 && b[i+1] == 0x85 || // NEL (#x85)
-		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA8 || // LS (#x2028)
-		b[i] == 0xE2 && b[i+1] == 0x80 && b[i+2] == 0xA9 || // PS (#x2029)
-		b[i] == 0)
-}
-
 // Check if the character is a line break, space, tab, or NUL.
 func is_blankz(b []byte, i int) bool {
 	//return is_blank(b, i) || is_breakz(b, i)
 	return (
-		// is_blank:
-		b[i] == ' ' || b[i] == '\t' ||
+	// is_blank:
+	b[i] == ' ' || b[i] == '\t' ||
 		// is_breakz:
 		b[i] == '\r' || // CR (#xD)
 		b[i] == '\n' || // LF (#xA)


### PR DESCRIPTION
The Tests workflow installs dependencies with lifecycle scripts disabled, so lint reaches its configured vendor-mode loader without the repository's ignored vendor tree and fails before analyzing source.

This change runs the existing vendor script explicitly before Go commands, completes the checksums needed by the tool bootstrap, and resolves the YAML findings that the loader failure masked. The YAML cleanup checks narrow integer conversions, removes unreachable private remnants, and adds directive coverage for supported and malformed input.

The generated vendor tree remains ignored and untracked. Existing module versions and public YAML APIs do not change.