### PR TITLE
fix(bus): join controller lifetimes during shutdown

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -6,7 +6,11 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/util/broadcast"
+	"github.com/pkg/errors"
 )
+
+// ErrClosed rejects controller admission after bus shutdown begins.
+var ErrClosed = errors.New("controller bus is closed")
 
 // ControllerCloseError reports a Controller.Close failure.
 //
@@ -15,6 +19,7 @@ import (
 // Callers can distinguish close failures from execution failures with
 // errors.As.
 type ControllerCloseError struct {
+	// Err is the controller's cleanup failure.
 	Err error
 }
 
@@ -66,4 +71,11 @@ type Bus interface {
 	// controller. It cancels that instance's Execute context, detaches
 	// directive handling, waits for Execute to return, and calls Close once.
 	RemoveController(controller.Controller)
+
+	// Close rejects new controllers, cancels admitted controllers, and waits
+	// for their Execute, Close, and completion callbacks, including releases
+	// already in progress. It returns joined ControllerCloseError values.
+	// Repeated calls wait for the same shutdown and return the same result.
+	// Call Close from the owning host, never from an owned controller lifecycle.
+	Close() error
 }

--- a/bus/inmem/controller.go
+++ b/bus/inmem/controller.go
@@ -3,27 +3,40 @@ package inmem
 import (
 	"context"
 	"errors"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
 )
 
+// releaseWarningInterval bounds the interval between cleanup diagnostics.
 const releaseWarningInterval = 30 * time.Second
 
 // attachedCtrl contains the lifecycle of one attached controller instance.
 type attachedCtrl struct {
+	// ctrl owns execution and resource cleanup.
 	ctrl controller.Controller
-	rel  func()
+	// rel detaches directive handling.
+	rel func()
+	// detached excludes a closing controller from active lookup; guarded by Bus.mtx.
+	detached bool
 
-	cancel      context.CancelFunc
+	// cancel stops execution.
+	cancel context.CancelFunc
+	// executeDone publishes executeErr after Execute returns.
 	executeDone chan struct{}
-	executeErr  error
-	callback    func(error)
+	// executeErr is read only after executeDone closes.
+	executeErr error
+	// callback receives the completed lifecycle result.
+	callback func(error)
 
-	finalizeOnce sync.Once
-	finalErr     error
+	// finalizing selects the single finalizer.
+	finalizing atomic.Bool
+	// finalized publishes finalErr after all cleanup completes.
+	finalized chan struct{}
+	// finalErr is read only by the finalizer or after finalized closes.
+	finalErr error
 }
 
 // newAttachedCtrl constructs an attached controller lifecycle.
@@ -38,6 +51,7 @@ func newAttachedCtrl(
 		rel:         rel,
 		cancel:      cancel,
 		executeDone: make(chan struct{}),
+		finalized:   make(chan struct{}),
 		callback:    callback,
 	}
 }
@@ -50,27 +64,31 @@ func (c *attachedCtrl) finishExecution(err error) {
 
 // finalize cancels, detaches, waits, closes, and reports exactly once.
 func (c *attachedCtrl) finalize(b *Bus) error {
-	c.finalizeOnce.Do(func() {
-		c.cancel()
-		b.detachController(c)
+	if !c.finalizing.CompareAndSwap(false, true) {
+		<-c.finalized
+		return c.finalErr
+	}
+	defer close(c.finalized)
+	defer b.forgetController(c)
+	c.cancel()
+	b.detachController(c)
 
-		ticker := time.NewTicker(releaseWarningInterval)
-		defer ticker.Stop()
-	waitForExecute:
-		for {
-			select {
-			case <-c.executeDone:
-				break waitForExecute
-			case <-ticker.C:
-				b.le.WithField("controller", c.ctrl).Warn("waiting for controller Execute to return")
-			}
+	ticker := time.NewTicker(releaseWarningInterval)
+	defer ticker.Stop()
+waitForExecute:
+	for {
+		select {
+		case <-c.executeDone:
+			break waitForExecute
+		case <-ticker.C:
+			b.le.WithField("controller", c.ctrl).Warn("waiting for controller Execute to return")
 		}
+	}
 
-		c.finalErr = joinControllerErrors(c.executeErr, c.ctrl.Close())
-		if c.callback != nil {
-			c.callback(c.finalErr)
-		}
-	})
+	c.finalErr = joinControllerErrors(c.executeErr, c.ctrl.Close())
+	if c.callback != nil {
+		c.callback(c.finalErr)
+	}
 	return c.finalErr
 }
 

--- a/bus/inmem/detach_test.go
+++ b/bus/inmem/detach_test.go
@@ -2,6 +2,7 @@ package inmem
 
 import "testing"
 
+// TestDetachControllerIsIdempotent checks public removal and one release notification.
 func TestDetachControllerIsIdempotent(t *testing.T) {
 	releaseCalls := 0
 	target := &attachedCtrl{
@@ -20,10 +21,10 @@ func TestDetachControllerIsIdempotent(t *testing.T) {
 	if got := releaseCalls; got != 1 {
 		t.Fatalf("release calls after first detach = %d, want 1", got)
 	}
-	if got := len(b.controllers); got != 1 {
+	if got := len(b.GetControllers()); got != 1 {
 		t.Fatalf("controller count after first detach = %d, want 1", got)
 	}
-	if b.controllers[0] != retained {
+	if !target.detached || retained.detached {
 		t.Fatal("retained controller changed after first detach")
 	}
 
@@ -44,10 +45,10 @@ func TestDetachControllerIsIdempotent(t *testing.T) {
 	if got := releaseCalls; got != 1 {
 		t.Fatalf("release calls after second detach = %d, want 1", got)
 	}
-	if got := len(b.controllers); got != 1 {
+	if got := len(b.GetControllers()); got != 1 {
 		t.Fatalf("controller count after second detach = %d, want 1", got)
 	}
-	if b.controllers[0] != retained {
+	if !target.detached || retained.detached {
 		t.Fatal("retained controller changed after second detach")
 	}
 	select {

--- a/bus/inmem/inmem.go
+++ b/bus/inmem/inmem.go
@@ -2,7 +2,9 @@ package inmem
 
 import (
 	"context"
+	stderrors "errors"
 	"runtime/debug"
+	"slices"
 	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -22,10 +24,18 @@ type Bus struct {
 	le *logrus.Entry
 	// bcast is signaled when controllers are added or removed.
 	bcast broadcast.Broadcast
-	// mtx guards below fields
+	// mtx guards admission and the retained controller lifetimes.
 	mtx sync.Mutex
-	// controllers is the set of attached controllers
+	// controllers retains admitted controllers until finalization completes.
 	controllers []*attachedCtrl
+	// closed rejects admission after the owner begins shutdown.
+	closed bool
+	// admitting joins handler registration before shutdown snapshots lifetimes.
+	admitting sync.WaitGroup
+	// closeOnce joins concurrent shutdown callers.
+	closeOnce sync.Once
+	// closeErr retains cleanup errors from the completed shutdown.
+	closeErr error
 }
 
 // NewBus constructs a new in-memory Bus with a directive controller.
@@ -45,9 +55,11 @@ func NewBusWithLogger(dc directive.Controller, le *logrus.Entry) *Bus {
 // GetControllers returns a list of all currently active controllers.
 func (b *Bus) GetControllers() []controller.Controller {
 	b.mtx.Lock()
-	c := make([]controller.Controller, len(b.controllers))
-	for i := range b.controllers {
-		c[i] = b.controllers[i].ctrl
+	c := make([]controller.Controller, 0, len(b.controllers))
+	for _, attached := range b.controllers {
+		if !attached.detached {
+			c = append(c, attached.ctrl)
+		}
 	}
 	b.mtx.Unlock()
 	return c
@@ -67,7 +79,7 @@ func (b *Bus) AddController(ctx context.Context, ctrl controller.Controller, cb 
 	attached, err := b.attachController(ctrl, subCtxCancel, cb)
 	if err != nil {
 		subCtxCancel()
-		return nil, joinControllerErrors(err, ctrl.Close())
+		return nil, err
 	}
 
 	go b.executeAttached(subCtx, attached)
@@ -114,7 +126,7 @@ func (b *Bus) ExecuteController(ctx context.Context, c controller.Controller) er
 	attached, err := b.attachController(c, subCtxCancel, nil)
 	if err != nil {
 		subCtxCancel()
-		return joinControllerErrors(err, c.Close())
+		return err
 	}
 
 	err = b.executeController(subCtx, c)
@@ -133,16 +145,52 @@ func (b *Bus) RemoveController(c controller.Controller) {
 	}
 }
 
+// Close rejects admission and joins every retained controller lifetime.
+func (b *Bus) Close() error {
+	b.closeOnce.Do(func() {
+		// Close admission before waiting for handler registration already in progress.
+		b.mtx.Lock()
+		b.closed = true
+		b.mtx.Unlock()
+		b.admitting.Wait()
+		b.mtx.Lock()
+		controllers := slices.Clone(b.controllers)
+		b.mtx.Unlock()
+
+		// Cancel all dependencies before joining any one controller's cleanup.
+		for _, attached := range controllers {
+			attached.cancel()
+		}
+		for _, attached := range controllers {
+			var closeErr *bus.ControllerCloseError
+			if stderrors.As(attached.finalize(b), &closeErr) {
+				b.closeErr = stderrors.Join(b.closeErr, closeErr)
+			}
+		}
+	})
+	return b.closeErr
+}
+
 // attachController registers and records one attached controller instance.
 func (b *Bus) attachController(
 	c controller.Controller,
 	cancel context.CancelFunc,
 	cb func(error),
 ) (*attachedCtrl, error) {
+	// Serialize admission with shutdown without holding the mutex across callbacks.
+	b.mtx.Lock()
+	if b.closed {
+		b.mtx.Unlock()
+		return nil, joinControllerErrors(bus.ErrClosed, c.Close())
+	}
+	b.admitting.Add(1)
+	b.mtx.Unlock()
+	defer b.admitting.Done()
+
 	// AddHandler may call HandleDirective, so it must run outside b.mtx.
 	rel, err := b.AddHandler(c)
 	if err != nil {
-		return nil, err
+		return nil, joinControllerErrors(err, c.Close())
 	}
 	attached := newAttachedCtrl(c, rel, cancel, cb)
 
@@ -160,37 +208,41 @@ func (b *Bus) findController(c controller.Controller) *attachedCtrl {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	for _, attached := range b.controllers {
-		if attached.ctrl == c {
+		if attached.ctrl == c && !attached.detached {
 			return attached
 		}
 	}
 	return nil
 }
 
-// detachController removes an exact attached instance and then releases its
-// directive handler without holding b.mtx.
+// detachController removes directive handling while retaining the closing lifetime.
 func (b *Bus) detachController(attached *attachedCtrl) {
-	var removed bool
 	b.mtx.Lock()
-	for i, candidate := range b.controllers {
-		if candidate == attached {
-			b.controllers[i] = b.controllers[len(b.controllers)-1]
-			b.controllers[len(b.controllers)-1] = nil
-			b.controllers = b.controllers[:len(b.controllers)-1]
-			removed = true
-			break
-		}
-	}
-	b.mtx.Unlock()
-
-	if !removed {
+	if attached.detached {
+		b.mtx.Unlock()
 		return
 	}
+	attached.detached = true
+	b.mtx.Unlock()
 	attached.rel()
 	b.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		broadcast()
 	})
 }
 
-// _ is a type assertion
-var _ bus.Bus = ((*Bus)(nil))
+// forgetController drops a lifetime only after its cleanup and callback complete.
+func (b *Bus) forgetController(attached *attachedCtrl) {
+	b.mtx.Lock()
+	for i, candidate := range b.controllers {
+		if candidate == attached {
+			b.controllers[i] = b.controllers[len(b.controllers)-1]
+			b.controllers[len(b.controllers)-1] = nil
+			b.controllers = b.controllers[:len(b.controllers)-1]
+			break
+		}
+	}
+	b.mtx.Unlock()
+}
+
+// _ is a type assertion.
+var _ bus.Bus = (*Bus)(nil)

--- a/bus/inmem/shutdown_test.go
+++ b/bus/inmem/shutdown_test.go
@@ -1,0 +1,143 @@
+package inmem
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/directive"
+)
+
+// TestCloseCancelsBeforeJoining checks dependency cancellation and cleanup errors.
+func TestCloseCancelsBeforeJoining(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b, _ := newTrackingBus()
+		firstClosing := make(chan struct{})
+		finishFirst := make(chan struct{})
+		var secondCanceled atomic.Bool
+		closeFailure := errors.New("close failed")
+		first := &lifecycleController{
+			executeFn: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+			closeFn: func() error {
+				close(firstClosing)
+				<-finishFirst
+				return closeFailure
+			},
+		}
+		second := &lifecycleController{executeFn: func(ctx context.Context) error {
+			<-ctx.Done()
+			secondCanceled.Store(true)
+			return nil
+		}}
+		for _, controller := range []*lifecycleController{first, second} {
+			if _, err := b.AddController(t.Context(), controller, nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+		closed := make(chan error, 1)
+		go func() { closed <- b.Close() }()
+		<-firstClosing
+		synctest.Wait()
+		if !secondCanceled.Load() {
+			t.Fatal("shutdown joined the first controller before canceling its dependency")
+		}
+		close(finishFirst)
+		if err := <-closed; !errors.Is(err, closeFailure) {
+			t.Fatalf("shutdown lost the cleanup error: %v", err)
+		}
+		if err := b.Close(); !errors.Is(err, closeFailure) {
+			t.Fatalf("repeated shutdown changed its result: %v", err)
+		}
+		if first.closeCalls.Load() != 1 || second.closeCalls.Load() != 1 || len(b.GetControllers()) != 0 {
+			t.Fatal("shutdown did not close each controller exactly once")
+		}
+		rejected := &lifecycleController{}
+		if _, err := b.AddController(t.Context(), rejected, nil); !errors.Is(err, bus.ErrClosed) || rejected.closeCalls.Load() != 1 {
+			t.Fatalf("closed bus admitted or leaked a controller: %v", err)
+		}
+	})
+}
+
+// TestCloseJoinsDetachedController checks a release that is already closing storage.
+func TestCloseJoinsDetachedController(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b, tracking := newTrackingBus()
+		closing := make(chan struct{})
+		finish := make(chan struct{})
+		controller := &lifecycleController{closeFn: func() error {
+			close(closing)
+			<-finish
+			return nil
+		}}
+		release, err := b.AddController(t.Context(), controller, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		released := make(chan struct{})
+		go func() { release(); close(released) }()
+		<-tracking.detached
+		<-closing
+		if len(b.GetControllers()) != 0 {
+			t.Fatal("closing controller remains publicly attached")
+		}
+		var complete atomic.Bool
+		closed := make(chan error, 1)
+		go func() {
+			closed <- b.Close()
+			complete.Store(true)
+		}()
+		synctest.Wait()
+		if complete.Load() {
+			t.Fatal("shutdown returned while detached controller cleanup was running")
+		}
+		close(finish)
+		<-released
+		if err := <-closed; err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// TestCloseJoinsAdmission checks handler registration racing with shutdown.
+func TestCloseJoinsAdmission(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		b, tracking := newTrackingBus()
+		entered := make(chan struct{})
+		proceed := make(chan struct{})
+		tracking.beforeAdd = func(directive.Handler) {
+			close(entered)
+			<-proceed
+		}
+		controller := &lifecycleController{}
+		admitted := make(chan error, 1)
+		go func() {
+			_, err := b.AddController(t.Context(), controller, nil)
+			admitted <- err
+		}()
+		<-entered
+		closed := make(chan error, 1)
+		go func() { closed <- b.Close() }()
+		synctest.Wait()
+		select {
+		case <-closed:
+			t.Fatal("shutdown returned before an admitted handler finished registration")
+		default:
+		}
+		close(proceed)
+		if err := <-admitted; err != nil {
+			t.Fatal(err)
+		}
+		if err := <-closed; err != nil {
+			t.Fatal(err)
+		}
+		if controller.closeCalls.Load() != 1 {
+			t.Fatal("shutdown lost the concurrently admitted controller")
+		}
+	})
+}


### PR DESCRIPTION
Hosts could exit while detached controllers were still cleaning up. Add Bus.Close to reject new controllers, cancel admitted controllers, and join execution, cleanup, and completion callbacks, including releases already underway.

The in-memory bus retains closing lifetimes separately from active discovery. Close returns cleanup errors and supports concurrent and repeated callers.

Validation: full Go suite; race tests for dependent cancellation, detached cleanup, concurrent admission, cleanup errors, and repeated shutdown. A downstream native CLI integration also verifies its database is closed before caller cleanup runs.
