### PR TITLE
fix(bus): avoid canceled transform result races

### DIFF
--- a/bus/inmem/oneoff_test.go
+++ b/bus/inmem/oneoff_test.go
@@ -1,0 +1,65 @@
+package inmem
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/directive"
+	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
+	boilerplate_v1 "github.com/aperturerobotics/controllerbus/example/boilerplate/v1"
+)
+
+// TestOneOffTransformCancellation allows cancellation to win while the accepted
+// value's transformation is still returning. Both APIs must return an empty
+// result on cancellation without accessing the callback's unpublished value.
+func TestOneOffTransformCancellation(t *testing.T) {
+	for _, typed := range []bool{false, true} {
+		for range 32 {
+			ctx, cancel := context.WithCancel(t.Context())
+			b := NewBus(directive_controller.NewController(t.Context(), nil))
+			ctrl := &lifecycleController{handleFn: func(context.Context, directive.Instance) ([]directive.Resolver, error) {
+				return directive.Resolvers(directive.NewValueResolver([]int{1})), nil
+			}}
+			release, err := b.AddController(t.Context(), ctrl, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			transform := func() {
+				cancel()
+				runtime.Gosched()
+			}
+			var value any
+			var ref directive.Reference
+			if typed {
+				var result *int
+				result, _, _, ref, err = bus.ExecOneOffWithXfrmTyped(ctx, b, &boilerplate_v1.Boilerplate{}, nil, nil, func(directive.TypedAttachedValue[int]) (*int, bool, error) {
+					transform()
+					return new(2), true, nil
+				})
+				if result != nil {
+					value = *result
+				}
+			} else {
+				value, _, _, ref, err = bus.ExecOneOffWithXfrm(ctx, b, &boilerplate_v1.Boilerplate{}, nil, nil, func(directive.AttachedValue) (directive.Value, bool, error) {
+					transform()
+					return 2, true, nil
+				})
+			}
+			if ref != nil {
+				ref.Release()
+			}
+			release()
+			cancel()
+			if errors.Is(err, context.Canceled) {
+				if value != nil {
+					t.Fatalf("cancellation returned an unpublished result: %v", value)
+				}
+			} else if err != nil || value != 2 {
+				t.Fatalf("successful transform returned value=%v err=%v", value, err)
+			}
+		}
+	}
+}

--- a/bus/oneoff.go
+++ b/bus/oneoff.go
@@ -95,7 +95,7 @@ func ExecOneOffWithFilter(
 	valDisposeCallback func(),
 	filterCb func(val directive.AttachedValue) (bool, error),
 ) (directive.AttachedValue, directive.Instance, directive.Reference, error) {
-	// mtx, bcast guard these variables
+	// bcast guards the result and idle state.
 	var bcast broadcast.Broadcast
 
 	var val directive.AttachedValue
@@ -289,7 +289,6 @@ func ExecOneOffWithXfrm(
 		idleCb,
 		valDisposeCallback,
 		func(val directive.AttachedValue) (bool, error) {
-			var ok bool
 			xval, ok, err := xfrmCb(val)
 			if !ok || err != nil {
 				return false, err
@@ -298,6 +297,10 @@ func ExecOneOffWithXfrm(
 			return true, nil
 		},
 	)
+	if err != nil || av == nil {
+		// Cancellation can return before the transform callback finishes.
+		return nil, av, di, ref, err
+	}
 	return xfrm, av, di, ref, err
 }
 
@@ -329,7 +332,6 @@ func ExecOneOffWithXfrmTyped[T, R directive.ComparableValue](
 		idleCb,
 		valDisposeCallback,
 		func(val directive.TypedAttachedValue[T]) (bool, error) {
-			var ok bool
 			xval, ok, err := xfrmCb(val)
 			if !ok || err != nil {
 				return false, err
@@ -339,9 +341,9 @@ func ExecOneOffWithXfrmTyped[T, R directive.ComparableValue](
 		},
 	)
 	if err != nil || av == nil {
-		// ensure xfrm is empty too
+		// Cancellation can return before the transform callback finishes.
 		var empty R
-		xfrm = empty
+		return empty, av, di, ref, err
 	}
 	return xfrm, av, di, ref, err
 }


### PR DESCRIPTION
A canceled one-off directive can return while its transformation callback is still finishing. Return an independent empty result on failure so the typed and untyped APIs never read or clear that unpublished callback value.

Validation: the new cancellation regression fails under the race detector before the change; go test -race ./bus/... passes after it.